### PR TITLE
Update users API for password changing and deleting

### DIFF
--- a/services/api/auth/acl.json
+++ b/services/api/auth/acl.json
@@ -10,7 +10,8 @@
     "permissions": [{
         "resource": "user/:id",
         "methods": [
-            "GET"
+            "GET",
+            "DELETE"
         ],
         "action": "allow"
     }, {
@@ -77,7 +78,8 @@
     "permissions": [{
         "resource": "user/:id",
         "methods": [
-            "GET"
+            "GET",
+            "DELETE"
         ],
         "action": "allow"
     }, {

--- a/services/api/users.js
+++ b/services/api/users.js
@@ -106,6 +106,42 @@ async function getUser(req, res, next) {
     }
 }
 
+async function deleteUser(req, res, next) {
+    const { id: targetId } = req.params
+    const { _id: requesterId, role: requesterRole } = req.user
+
+    if (!isValidId(targetId)) {
+        return next(createError(400, 'Unvalid ID'))
+    }
+
+    if (requesterRole !== ROLES.ADMIN && requesterId.toString() !== targetId) {
+        return next(createError(400, 'Request non-self user'))
+    }
+
+    try {
+        const targetUser = await models.users.findById(targetId)
+
+        if (!targetUser) {
+            return next(createError(404, 'User not existed'))
+        }
+
+        if (targetUser.role === ROLES.ADMIN) {
+            // Deletion of admin user is not allowed.
+            return next(createError(400, 'Deletion of admin user is not allowed'))
+        }
+
+        const result = await models.users.findByIdAndRemove(targetId)
+
+        if (!result) {
+            return next(createError(404, 'User not existed'))
+        }
+
+        return res.status(204).send()
+    } catch (err) {
+        return next(createError(500, null, err))
+    }
+}
+
 async function changePassword(req, res, next) {
     const { id: targetId } = req.params
     const { _id: requesterId, role: requesterRole } = req.user
@@ -196,6 +232,7 @@ routesWithAuth(
 routesWithAuth(
     router,
     ['get', '/user/:id', getUser],
+    ['delete', '/user/:id', deleteUser],
     ['patch', '/user/:id/password', changePasswordValidator, validate, changePassword],
 )
 router.post('/login', userValidator, validate, login)

--- a/services/api/users.js
+++ b/services/api/users.js
@@ -15,6 +15,7 @@ const getUserProjection = {
     '_id': 1,
     'username': 1,
     'role': 1,
+    'passwordLastUpdated': 1,
 }
 
 const router = express.Router()
@@ -120,6 +121,7 @@ async function changePassword(req, res, next) {
     try {
         const updated = {
             password: req.body.password,
+            passwordLastUpdated: new Date(),
         }
         const options = {
             new: true,
@@ -138,7 +140,7 @@ async function changePassword(req, res, next) {
 }
 
 async function login(req, res, next) {
-    const { username, password, role } = req.body
+    const { username, password } = req.body
 
     try {
         const result = await models.users.findOne({

--- a/shared/database.json
+++ b/shared/database.json
@@ -37,6 +37,9 @@
             "type": "String",
             "required": true,
             "enum": [ "admin", "writer", "reader" ]
+        },
+        "passwordLastUpdated": {
+            "type": "Date"
         }
     },
     "analyzers": {


### PR DESCRIPTION
1. Add `passwordLastModified` field when getting user(s). the filed has value only when the user's password has changed.
2. Add a new end point for user deletion: `/user/:id` (`DELETE`). Deletion of admin user is not allowed.