### PR TITLE
Use UTC format for date field in event

### DIFF
--- a/apps/analyzer.py
+++ b/apps/analyzer.py
@@ -237,9 +237,7 @@ def analyzer_main_func(signal, cluster, anal_id, name, source, pipelines):
                     message = {
                         "analyzerId": anal_id,
                         "timestamp": event.timestamp,
-                        "date": (datetime.datetime
-                                 .fromtimestamp(event.timestamp)
-                                 .strftime("%Y-%m-%d %H:%M:%S")),
+                        "date": datetime.datetime.utcfromtimestamp(event.timestamp),
                         "type": event.name,
                         "content": event.content
                     }


### PR DESCRIPTION
UTC format is a timezone agnostic presentation of date. No matter what timezone we are, the date will always be the same.

For example, A and B are in different timezone. A is in *Asia/Taipei (GMT+8)* and current time is 2018/5/17 12:27:13. B is in *Asia/Tokyo (GMT+9)* and current time is 2018/5/17 13:27:13. The
UTC date of A and B are the same, i.e., `2018-05-17T04:27:13Z`.